### PR TITLE
Fix netlify 404 error on refreshing the app

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
## Changes in this pull request
> In this pull request I
- Implemented a fix to the `404` error experienced when a user refreshes the app on [Netlify](https://doctora-app.netlify.app/)